### PR TITLE
feat: API 응답값 형태 통일

### DIFF
--- a/components/core/src/main/kotlin/com/sangsiklog/core/api/exception/CustomException.kt
+++ b/components/core/src/main/kotlin/com/sangsiklog/core/api/exception/CustomException.kt
@@ -1,0 +1,8 @@
+package com.sangsiklog.core.api.exception
+
+import org.springframework.http.HttpStatus
+
+data class CustomException(
+    val status: HttpStatus,
+    val errorType: ErrorType
+): Exception()

--- a/components/core/src/main/kotlin/com/sangsiklog/core/api/exception/ErrorType.kt
+++ b/components/core/src/main/kotlin/com/sangsiklog/core/api/exception/ErrorType.kt
@@ -1,0 +1,8 @@
+package com.sangsiklog.core.api.exception
+
+enum class ErrorType(
+    val code: Int,
+    val message: String
+) {
+    TEST_ERROR_TYPE(0, "Test error type")
+}

--- a/components/core/src/main/kotlin/com/sangsiklog/core/api/handler/ApiExceptionHandler.kt
+++ b/components/core/src/main/kotlin/com/sangsiklog/core/api/handler/ApiExceptionHandler.kt
@@ -1,0 +1,114 @@
+package com.sangsiklog.core.api.handler
+
+import com.sangsiklog.core.api.exception.CustomException
+import com.sangsiklog.core.api.response.ApiErrorResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.BindException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.NoHandlerFoundException
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import java.util.*
+
+
+@RestControllerAdvice(basePackages = ["com.sangsiklog.command.controller", "com.sangsiklog.query.controller"])
+class ApiExceptionHandler: ResponseEntityExceptionHandler() {
+
+    private val messageMappings: Map<Class<out Exception?>, String> = Collections
+        .unmodifiableMap(
+            linkedMapOf(
+                Pair(MethodArgumentNotValidException::class.java, "Request body is invalid")
+            )
+        )
+
+    override fun handleMethodArgumentNotValid(
+        ex: MethodArgumentNotValidException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any>? {
+        val responseBody = ApiErrorResponse(
+            code = status.value(),
+            message = resolveMessage(ex, ex.message),
+            details = getDetails(ex)
+        )
+
+        return super.handleExceptionInternal(ex, responseBody, headers, status, request)
+    }
+
+    override fun handleNoHandlerFoundException(
+        ex: NoHandlerFoundException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any>? {
+        val responseBody = ApiErrorResponse(
+            code = status.value(),
+            message = ex.message,
+            details = null
+        )
+
+        return super.handleExceptionInternal(ex, responseBody, headers, status, request)
+    }
+
+    override fun handleExceptionInternal(
+        ex: Exception,
+        body: Any?,
+        headers: HttpHeaders,
+        statusCode: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any>? {
+        val responseBody = ApiErrorResponse(
+            code = statusCode.value(),
+            message = ex.message,
+            details = body
+        )
+
+        return super.handleExceptionInternal(ex, responseBody, headers, statusCode, request)
+    }
+
+    @ExceptionHandler
+    fun handleCustomException(ex: CustomException, request: WebRequest): ResponseEntity<Any>? {
+        val responseBody = ApiErrorResponse(
+            code = ex.errorType.code,
+            message = ex.errorType.message,
+            details = null
+        )
+
+        return super.handleExceptionInternal(ex, responseBody, HttpHeaders(), ex.status, request)
+    }
+
+    private fun resolveMessage(ex: Exception, defaultMessage: String): String {
+        return messageMappings.entries
+            .firstOrNull { entry -> entry.key.isAssignableFrom(ex.javaClass) }
+            ?.value ?: defaultMessage
+    }
+
+    private fun getDetails(ex: BindException): List<HashMap<String, String?>> {
+        val details: MutableList<HashMap<String, String?>> = mutableListOf()
+
+        if (ex is MethodArgumentNotValidException) {
+            ex.bindingResult.globalErrors.forEach { error ->
+                val detail: HashMap<String, String?> = hashMapOf()
+                detail["target"] = error.objectName;
+                detail["message"] = error.defaultMessage;
+
+                details.add(detail)
+            }
+        }
+
+        ex.bindingResult.fieldErrors.forEach { error ->
+            val detail: HashMap<String, String?> = hashMapOf()
+            detail["target"] = error.field
+            detail["message"] = error.defaultMessage;
+
+            details.add(detail)
+        }
+
+        return details
+    }
+}

--- a/components/core/src/main/kotlin/com/sangsiklog/core/api/handler/ResponseHandler.kt
+++ b/components/core/src/main/kotlin/com/sangsiklog/core/api/handler/ResponseHandler.kt
@@ -1,0 +1,44 @@
+package com.sangsiklog.core.api.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sangsiklog.core.api.response.ApiErrorResponse
+import com.sangsiklog.core.api.response.ApiResponse
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+@RestControllerAdvice(basePackages = ["com.sangsiklog.command.controller", "com.sangsiklog.query.controller"])
+class ResponseHandler: ResponseBodyAdvice<Any> {
+    private val objectMapper = ObjectMapper()
+
+    override fun supports(returnType: MethodParameter, converterType: Class<out HttpMessageConverter<*>>): Boolean {
+        return true
+    }
+
+    override fun beforeBodyWrite(
+        body: Any?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse
+    ): Any? {
+        return when (body) {
+            is ApiErrorResponse<*> -> {
+                body
+            }
+            is String -> {
+                response.headers.contentType = MediaType.APPLICATION_JSON
+                objectMapper.writeValueAsString(ApiResponse(HttpStatus.OK.value(), "success", body))
+            }
+            else -> {
+                ApiResponse(HttpStatus.OK.value(), "success", body)
+            }
+        }
+    }
+}

--- a/components/core/src/main/kotlin/com/sangsiklog/core/api/response/ApiErrorResponse.kt
+++ b/components/core/src/main/kotlin/com/sangsiklog/core/api/response/ApiErrorResponse.kt
@@ -1,0 +1,7 @@
+package com.sangsiklog.core.api.response
+
+data class ApiErrorResponse<T> (
+    val code: Int,
+    val message: String? = null,
+    val details: T? = null
+)

--- a/components/core/src/main/kotlin/com/sangsiklog/core/api/response/ApiResponse.kt
+++ b/components/core/src/main/kotlin/com/sangsiklog/core/api/response/ApiResponse.kt
@@ -1,0 +1,7 @@
+package com.sangsiklog.core.api.response
+
+data class ApiResponse<T> (
+    val code: Int,
+    val message: String? = null,
+    val result: T? = null
+)

--- a/components/knowledge/src/main/kotlin/com/sangsiklog/query/controller/QueryTestController.kt
+++ b/components/knowledge/src/main/kotlin/com/sangsiklog/query/controller/QueryTestController.kt
@@ -1,6 +1,9 @@
 package com.sangsiklog.query.controller
 
+import com.sangsiklog.core.api.exception.CustomException
+import com.sangsiklog.core.api.exception.ErrorType
 import com.sangsiklog.core.log.logger
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -12,6 +15,15 @@ class QueryTestController {
     @GetMapping
     fun testLogging(): String {
         logger.info("query controller test logging called")
+        return "testLogging"
+    }
+
+    @GetMapping("/exception")
+    fun testExceptionResponse(): String {
+        logger.info("query controller test logging called")
+
+        throw CustomException(HttpStatus.BAD_REQUEST, ErrorType.TEST_ERROR_TYPE)
+
         return "testLogging"
     }
 }


### PR DESCRIPTION
API 응답값 형태 통일
RestControllerAdvice 구현
- ResponseHandler(정상 응답값 Wrapping 처리)
- ApiExceptionHandler(Exception 응답값 처리)

BREAKING CHANGE: https://github.com/SangsikLog/sangsiklog-api/issues/17

- 정상 응답값 형태
<img width="1136" alt="스크린샷 2024-07-19 오후 6 31 52" src="https://github.com/user-attachments/assets/585c6808-17a6-4792-a4ab-14477f2ed889">

- 예외 발생 응답값 형태
<img width="1138" alt="스크린샷 2024-07-19 오후 6 32 01" src="https://github.com/user-attachments/assets/167594ea-6417-4877-96db-ac85de562105">

